### PR TITLE
DIGI-7525 Update SDK to expose additional data

### DIFF
--- a/DigiMeFramework/Classes/DMEArgonServiceController.h
+++ b/DigiMeFramework/Classes/DMEArgonServiceController.h
@@ -40,6 +40,7 @@ extern const struct ArgonErrorCodes
 
 - (BOOL)sessionKeyIsValid:(NSString*)sessionKey;
 
+- (void)getAccountsDataWithCompletion:(void(^)(NSDictionary * _Nullable accounts, NSError * _Nullable error))completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DigiMeFramework/Classes/DigiMeFramework.h
+++ b/DigiMeFramework/Classes/DigiMeFramework.h
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSInteger, DigiMeFrameworkErrorCode) {
     ErrorDataGetFilesListDataIsNotCorrect                                          = 740003,
     ErrorDataGetFileDataServerResponseWithError                                    = 740004,
     ErrorDataGetFileDataDataIsNotCorrect                                           = 740005,
+    ErrorDataGetFileAccountsDataSessionKeyIsNotAvailable                           = 740006,
     
     ErrorSchemaAppCommunicationsUnknown                                            = 750000,
     ErrorSchemaAppCommunicationsErrorSendingDataToDigimeAppNotAvailable            = 750001,
@@ -161,6 +162,27 @@ typedef NS_ENUM(NSInteger, DigiMeFrameworkErrorCode) {
 - (BOOL)digimeFrameworkApplication:(UIApplication *) application
                            openURL:(NSURL *) url
                            options:(NSDictionary *) options;
+
+/**
+ ///------------------------------------------------------------------------------------------------------
+ /// @name Consent Access    *** Receive account specific information
+ ///------------------------------------------------------------------------------------------------------
+ *
+ * @param         accountID         Account Entity ID 
+ * @param         completion        A handler block to execute. The block argument is a json object of an account specific information.
+ */
+- (void)digimeFrameworkGetAccountInfoWithAccountID:(nonnull NSString *) accountID
+                                    withCompletion:(nonnull void (^)(NSDictionary * _Nullable accountInfo)) completion;
+
+/**
+ ///------------------------------------------------------------------------------------------------------
+ /// @name Consent Access    *** Receive data about all available accounts
+ ///------------------------------------------------------------------------------------------------------
+ *
+ * @param         completion        A handler block to execute. The block argument is a json object of all available accounts.
+ */
+- (void)digimeFrameworkGetAllAccountsInfoWithCompletion:(nonnull void (^)(NSDictionary * _Nullable accounts)) completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DigiMeFramework/Classes/NSError+Helper.m
+++ b/DigiMeFramework/Classes/NSError+Helper.m
@@ -72,7 +72,11 @@
         case ErrorDataGetFileDataDataIsNotCorrect:
             return NSLocalizedString(@"digi.me Consent Access. File Data Data Is Not Correct",nil);
             break;
-
+            
+        case ErrorDataGetFileAccountsDataSessionKeyIsNotAvailable:
+            return NSLocalizedString(@"digi.me Consent Access. Get Accounts Data Session Key Is Not Available",nil);
+            break;
+            
         case ErrorSchemaAppCommunicationsUnknown:
             return NSLocalizedString(@"digi.me Consent Access. Schema App Communications Unknown Error",nil);
             break;


### PR DESCRIPTION
Ver 1.0.2 of iOS digi.me SDK was one way loop. You have to start from the beginning - to call 
```- (void)digimeFrameworkInitiateDataRequestWithAppID: appID contractID: contractID rsaPrivateKeyHex: privateKeyHex``` then you will get the result data with delegate methods. (pure unencrypted JFS as well as the log or error messages, also the action states) at the end of every loop SDK was cleaned and reset and waiting for the new loop to handle.

Here is the list of changes:
- SDK will be not reseted at the end of the loop. The reset will happen at every beginning when you create a session key. This change will allow to execute other calls after session was created.
- Added 2 public methods to retrieve account information. One method is to return all available accounts in json format and another call is to get account details based on digi.me JFS AccountEntityId. After the whole CA data was received we call internally the second method to initialise Accounts property and provide it for the public SDK calls. 